### PR TITLE
Add OmniDebug Autopilot skill with browser repro automation

### DIFF
--- a/omnidebug-autopilot/.gitignore
+++ b/omnidebug-autopilot/.gitignore
@@ -1,0 +1,3 @@
+scripts/__pycache__/
+scripts/*.pyc
+.debug/

--- a/omnidebug-autopilot/SKILL.md
+++ b/omnidebug-autopilot/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: omnidebug-autopilot
+description: Autonomous end-to-end debugging skill for any codebase, language, and framework. Detects stack, reproduces failures, isolates root cause, applies minimal safe fixes, and verifies with tests/build/lint without user interruption.
+license: MIT
+metadata:
+  version: 1.0.0
+  category: debugging
+---
+
+# OmniDebug Autopilot
+
+// TODO: split SKILL.md into smaller modules/components
+
+Universal debugging skill for apps, services, libraries, and scripts across mainstream stacks.
+Default mode is autonomous execution: find root cause and ship a verified fix without pausing for user input.
+
+## Quick Start
+
+Use this skill when requests include:
+- "debug this"
+- "fix this bug"
+- "why is this failing"
+- "find root cause"
+- "auto fix"
+
+Execution contract:
+1. Detect language, framework, package manager, and test runner.
+2. Reproduce the failure with a single deterministic command.
+3. Collect evidence from logs, traces, network, and failing tests.
+4. Isolate the smallest root cause (code, config, env, data, dependency, race, permissions).
+5. Apply the minimum correct fix.
+6. Re-run verification gates until green.
+
+## Non-Interruption Policy
+
+- Do not ask follow-up questions during normal debugging.
+- Continue autonomously through analysis, patching, and verification.
+- Only stop when blocked by missing secrets, unavailable infrastructure, or destructive action risk.
+- If blocked, use the safest fallback and continue as far as possible.
+
+## Mainstream Debug Process
+
+### Phase 1: Triage
+
+- Capture exact error text and failing command.
+- Use debugging tools first: console logs and network requests before code edits.
+- Identify regression window from recent diffs if available.
+- Determine scope: runtime error, failing test, build failure, performance issue, or security defect.
+
+### Phase 2: Reproduction
+
+- Create one reproducible command.
+- Remove noise by disabling unrelated jobs and minimizing input.
+- Prefer deterministic seeds and controlled timing.
+- Confirm failure reproduces at least twice.
+- Browser-specific reproducibility rules:
+  - Pin browser (`chromium`/`firefox`/`webkit`), viewport, locale, and timezone.
+  - Freeze test data and seed values.
+  - Disable retries during repro.
+  - Persist traces, screenshots, videos, and HAR files.
+
+### Phase 3: Evidence Collection
+
+Collect only relevant artifacts:
+- Console and application logs
+- Test output with stack traces
+- Network failures and status codes
+- Runtime metrics (latency, memory, CPU) when performance related
+- Config/env differences between working and failing contexts
+- Browser artifacts bundle:
+  - Devtools console log export
+  - Failed request waterfall with request/response metadata
+  - Reproduction trace and screenshot at failure frame
+  - Browser/version and OS metadata
+
+### Phase 4: Root Cause Analysis
+
+Use this chain:
+1. Symptom statement
+2. Immediate fault location
+3. Underlying mechanism
+4. Trigger condition
+5. Why safeguards missed it
+
+Root cause must be a single falsifiable statement tied to evidence.
+
+### Phase 5: Fix Strategy
+
+- Prefer the smallest change that resolves cause, not symptom masking.
+- Keep public API behavior stable unless the bug requires a behavior correction.
+- Add or update tests that fail before and pass after fix.
+- Avoid temporary bypasses (`@ts-ignore`, disabled tests, silent catches).
+
+### Phase 6: Verification Gates
+
+All applicable gates must pass:
+- Unit, integration, and e2e tests
+- Lint and static analysis
+- Type checks
+- Build and package
+- Relevant runtime smoke check
+
+If any gate fails, loop back to Phase 4.
+
+## Browser Reproduction Module
+
+Use these scripts for browser bug reproduction and fix validation:
+
+```bash
+# 1) Reproduce failure deterministically (expected to fail)
+python scripts/repro_browser_issue.py \
+  --project-root . \
+  --repro-cmd "pnpm exec playwright test tests/bug.spec.ts --project=chromium --workers=1 --retries=0" \
+  --expect fail \
+  --runs 2
+
+# 2) Capture browser debugging artifacts into one bundle
+python scripts/capture_browser_artifacts.py --project-root . --output-dir .debug/browser-artifacts
+
+# 3) Verify fix deterministically (expected to pass)
+python scripts/verify_browser_fix.py \
+  --project-root . \
+  --verify-cmd "pnpm exec playwright test tests/bug.spec.ts --project=chromium --workers=1 --retries=0" \
+  --runs 2 \
+  --signature-file .debug/browser-repro/repro_report.json
+```
+
+Supported frameworks: Playwright, Cypress, Selenium, WebdriverIO.
+Use project-native commands first; scripts only orchestrate repeatable debug workflow.
+
+## Stack Detection and Default Commands
+
+| Stack | Detect Signals | Verify Commands |
+|------|----------------|----------------|
+| Node.js / TypeScript | `package.json`, `tsconfig.json` | `pnpm test`, `pnpm lint`, `pnpm typecheck`, `pnpm build` |
+| Python | `pyproject.toml`, `requirements.txt` | `pytest -q`, `ruff check .`, `mypy .` |
+| Go | `go.mod` | `go test ./...`, `go vet ./...` |
+| Rust | `Cargo.toml` | `cargo test`, `cargo clippy -- -D warnings` |
+| Java/Kotlin | `build.gradle`, `pom.xml` | `./gradlew test`, `./gradlew build` or `mvn test` |
+| Ruby | `Gemfile` | `bundle exec rspec`, `bundle exec rubocop` |
+| PHP | `composer.json` | `composer test`, `vendor/bin/phpunit` |
+| .NET | `*.sln`, `*.csproj` | `dotnet test`, `dotnet build` |
+| Swift (iOS/macOS) | `Package.swift`, `*.xcodeproj` | `swift test` or `xcodebuild test` |
+
+Pick commands from project scripts first; use defaults only if scripts are missing.
+
+## Auto-Fix Heuristics
+
+Prioritize fixes in this order:
+1. Incorrect logic or branching
+2. Null and undefined handling at source
+3. Async and concurrency ordering
+4. Contract and schema mismatch
+5. Config and environment mismatch
+6. Dependency incompatibility
+7. Resource, path, or permission issues
+
+For each candidate fix:
+- Estimate blast radius
+- Choose the lowest-risk valid option
+- Verify with targeted tests, then full gates
+
+## Guardrails
+
+- Never claim success without passing verification.
+- Never skip tests to make status green.
+- Never introduce permanent production `console.log` noise.
+- Never hardcode secrets or private endpoints.
+- Preserve existing style and architecture conventions.
+
+## Completion Criteria
+
+A task is complete only when all are true:
+- Reproduction exists for the original failure
+- Root cause statement is evidence-backed
+- Fix addresses root cause directly
+- Verification gates pass
+- Regression coverage is added or updated
+
+## Output Format
+
+Return concise sections:
+1. Root cause
+2. Applied fix
+3. Verification commands and results
+4. Remaining risk (if any)
+
+## Resources
+
+- `references/browser-repro-playbook.md`
+- `references/browser-artifact-checklist.md`
+- `scripts/repro_browser_issue.py`
+- `scripts/capture_browser_artifacts.py`
+- `scripts/verify_browser_fix.py`

--- a/omnidebug-autopilot/references/browser-artifact-checklist.md
+++ b/omnidebug-autopilot/references/browser-artifact-checklist.md
@@ -1,0 +1,55 @@
+# Browser Artifact Checklist
+
+Use this checklist for every browser bug.
+
+## Required Artifacts
+
+- [ ] Reproduction command used
+- [ ] Browser name and version
+- [ ] OS and architecture
+- [ ] Failing test output with stack trace
+- [ ] Console log export
+- [ ] Failed network requests list (URL, method, status)
+- [ ] Screenshot at failure state
+
+## Strongly Recommended
+
+- [ ] Trace file
+- [ ] HAR file
+- [ ] Video recording
+- [ ] DOM snapshot around failing node
+- [ ] Git commit SHA of test run
+
+## Artifact Quality Rules
+
+- Timestamps must be included.
+- File names should include run index and browser.
+- Redact secrets/tokens before sharing.
+- Keep raw outputs; do not only keep summarized logs.
+
+## Minimal Folder Structure
+
+```text
+.debug/browser-artifacts/
+├─ metadata.json
+├─ console/
+├─ network/
+├─ traces/
+├─ screenshots/
+└─ videos/
+```
+
+## Run Labels
+
+Use consistent labels:
+- `repro-run-1`
+- `repro-run-2`
+- `verify-run-1`
+- `verify-run-2`
+
+## Exit Conditions
+
+Artifact capture is complete when:
+- all required artifacts exist
+- files are non-empty
+- metadata maps artifact to command and run index

--- a/omnidebug-autopilot/references/browser-repro-playbook.md
+++ b/omnidebug-autopilot/references/browser-repro-playbook.md
@@ -1,0 +1,64 @@
+# Browser Reproduction Playbook
+
+Goal: produce deterministic reproduction for frontend/browser bugs before patching.
+
+## Step 1: Lock Environment
+
+- Pin browser target: `chromium`, `firefox`, or `webkit`.
+- Pin viewport (for example `1280x720`).
+- Pin locale and timezone.
+- Disable retries and parallel workers during reproduction.
+- Freeze network/data inputs when possible.
+
+## Step 2: Single Repro Command
+
+Create one command that fails reliably.
+
+Examples:
+- Playwright:
+  - `pnpm exec playwright test tests/bug.spec.ts --project=chromium --workers=1 --retries=0`
+- Cypress:
+  - `pnpm exec cypress run --spec cypress/e2e/bug.cy.ts --browser chrome`
+- Selenium/WebdriverIO:
+  - use project test command with one test file and one worker.
+
+## Step 3: Run Twice Minimum
+
+- A reproduction is valid only if it fails at least 2 times with same signature.
+- Signature means same core error class and stack segment.
+- If signatures differ, mark issue as flaky and stabilize test input first.
+
+## Step 4: Capture Artifacts
+
+Collect:
+- Console logs
+- Network request failures and status codes
+- Trace file if available
+- Screenshot at failure frame
+- Video (optional but helpful)
+- Browser and OS metadata
+
+## Step 5: Root Cause Mapping
+
+Map the failure from symptom to cause:
+1. Symptom shown in UI or assertion
+2. Failing request or event
+3. Fault location in source
+4. Data or timing trigger
+5. Missing guard/test that allowed regression
+
+Root cause statement must be falsifiable and tied to at least one artifact.
+
+## Step 6: Fix and Re-Verify
+
+- Apply smallest safe fix.
+- Re-run same repro command twice; both runs must pass.
+- Re-run full suite gates (lint/type/test/build).
+- Confirm previous signature does not appear in outputs.
+
+## Anti-Patterns
+
+- Debugging by random changes without deterministic repro.
+- Enabling retries to hide failures during root-cause stage.
+- Fixing UI symptom while backend/request bug remains.
+- Claiming success without re-running the exact repro command.

--- a/omnidebug-autopilot/scripts/capture_browser_artifacts.py
+++ b/omnidebug-autopilot/scripts/capture_browser_artifacts.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Collect browser debugging artifacts into a single bundle with manifest metadata."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+DEFAULT_PATTERNS = [
+    "**/*.png",
+    "**/*.jpg",
+    "**/*.jpeg",
+    "**/*.webm",
+    "**/*.mp4",
+    "**/*.har",
+    "**/*.trace",
+    "**/*trace*.zip",
+    "**/*playwright*.log",
+]
+
+DEFAULT_SEARCH_DIRS = ["test-results", "playwright-report", ".debug", "cypress"]
+
+
+@dataclass
+class Artifact:
+    source: str
+    target: str
+    size: int
+    sha256: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Capture browser debug artifacts")
+    parser.add_argument("--project-root", default=".")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--max-files", type=int, default=500)
+    parser.add_argument("--allow-empty", action="store_true")
+    parser.add_argument("--pattern", action="append", dest="patterns")
+    return parser.parse_args()
+
+
+def file_hash(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        while True:
+            chunk = fh.read(1024 * 1024)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.project_root).resolve()
+    out_dir = Path(args.output_dir).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    patterns = args.patterns if args.patterns else DEFAULT_PATTERNS
+
+    candidates: list[Path] = []
+    for rel in DEFAULT_SEARCH_DIRS:
+        base = root / rel
+        if not base.exists():
+            continue
+        for pattern in patterns:
+            candidates.extend(base.glob(pattern))
+
+    unique_files = []
+    seen = set()
+    for path in candidates:
+        if not path.is_file():
+            continue
+        full = path.resolve()
+        if str(full) in seen:
+            continue
+        seen.add(str(full))
+        unique_files.append(full)
+        if len(unique_files) >= args.max_files:
+            break
+
+    artifacts: list[Artifact] = []
+    for src in unique_files:
+        rel = src.relative_to(root) if src.is_relative_to(root) else Path(src.name)
+        target = out_dir / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, target)
+        artifacts.append(
+            Artifact(
+                source=str(src),
+                target=str(target),
+                size=target.stat().st_size,
+                sha256=file_hash(target),
+            )
+        )
+
+    manifest = {
+        "project_root": str(root),
+        "output_dir": str(out_dir),
+        "artifact_count": len(artifacts),
+        "artifacts": [asdict(item) for item in artifacts],
+    }
+    manifest_path = out_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    print(json.dumps(manifest, indent=2))
+    print(f"manifest: {manifest_path}")
+
+    if artifacts or args.allow_empty:
+        return 0
+    return 10
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/omnidebug-autopilot/scripts/repro_browser_issue.py
+++ b/omnidebug-autopilot/scripts/repro_browser_issue.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Run a browser reproduction command multiple times and validate deterministic failure."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+SIGNATURE_HINTS = (
+    "TypeError",
+    "ReferenceError",
+    "TimeoutError",
+    "AssertionError",
+    "expect(",
+    "Error:",
+)
+
+
+@dataclass
+class RunResult:
+    index: int
+    exit_code: int
+    duration_ms: int
+    signature: str
+    stdout_file: str
+    stderr_file: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Deterministic browser issue reproducer")
+    parser.add_argument("--project-root", default=".")
+    parser.add_argument("--repro-cmd", required=True)
+    parser.add_argument("--runs", type=int, default=2)
+    parser.add_argument("--expect", choices=["fail", "pass"], default="fail")
+    parser.add_argument("--output-dir", default=".debug/browser-repro")
+    return parser.parse_args()
+
+
+def extract_signature(output: str) -> str:
+    for line in output.splitlines():
+        text = line.strip()
+        if not text:
+            continue
+        if any(hint in text for hint in SIGNATURE_HINTS):
+            return text[:240]
+    for line in output.splitlines():
+        text = line.strip()
+        if text:
+            return text[:240]
+    return ""
+
+
+def run_once(cmd: str, cwd: Path, output_dir: Path, index: int) -> RunResult:
+    start = time.time()
+    proc = subprocess.run(cmd, cwd=str(cwd), shell=True, text=True, capture_output=True)
+    duration_ms = int((time.time() - start) * 1000)
+    stdout_path = output_dir / f"run_{index}.stdout.log"
+    stderr_path = output_dir / f"run_{index}.stderr.log"
+    stdout_path.write_text(proc.stdout or "", encoding="utf-8")
+    stderr_path.write_text(proc.stderr or "", encoding="utf-8")
+    signature = extract_signature((proc.stderr or "") + "\n" + (proc.stdout or ""))
+    return RunResult(
+        index=index,
+        exit_code=proc.returncode,
+        duration_ms=duration_ms,
+        signature=signature,
+        stdout_file=str(stdout_path),
+        stderr_file=str(stderr_path),
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.project_root).resolve()
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    runs: list[RunResult] = []
+    for i in range(1, args.runs + 1):
+        runs.append(run_once(args.repro_cmd, root, output_dir, i))
+
+    failed = sum(1 for run in runs if run.exit_code != 0)
+    passed = len(runs) - failed
+    signatures = [run.signature for run in runs if run.signature]
+    signature_consistent = bool(signatures) and len(set(signatures)) == 1
+
+    if args.expect == "fail":
+        reproducible = failed == len(runs) and signature_consistent
+    else:
+        reproducible = passed == len(runs)
+
+    report = {
+        "command": args.repro_cmd,
+        "expected": args.expect,
+        "reproducible": reproducible,
+        "runs": len(runs),
+        "failed_runs": failed,
+        "passed_runs": passed,
+        "signature_consistent": signature_consistent,
+        "common_signature": signatures[0] if signature_consistent else "",
+        "details": [asdict(run) for run in runs],
+    }
+
+    report_path = output_dir / "repro_report.json"
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    print(f"report: {report_path}")
+    return 0 if reproducible else 10
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/omnidebug-autopilot/scripts/verify_browser_fix.py
+++ b/omnidebug-autopilot/scripts/verify_browser_fix.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Verify browser fix by rerunning deterministic command and checking old signature is gone."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass
+class RunResult:
+    index: int
+    exit_code: int
+    duration_ms: int
+    stdout_file: str
+    stderr_file: str
+    forbidden_hit: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Deterministic browser fix verifier")
+    parser.add_argument("--project-root", default=".")
+    parser.add_argument("--verify-cmd", required=True)
+    parser.add_argument("--runs", type=int, default=2)
+    parser.add_argument("--output-dir", default=".debug/browser-verify")
+    parser.add_argument("--signature-file")
+    parser.add_argument("--must-not-contain", action="append", dest="forbidden")
+    return parser.parse_args()
+
+
+def load_forbidden_patterns(signature_file: str | None, manual: list[str] | None) -> list[str]:
+    patterns: list[str] = manual[:] if manual else []
+    if not signature_file:
+        return [item for item in patterns if item]
+    path = Path(signature_file)
+    if not path.exists():
+        return [item for item in patterns if item]
+    data = json.loads(path.read_text(encoding="utf-8"))
+    common = data.get("common_signature", "")
+    if common:
+        patterns.append(common)
+    return [item for item in patterns if item]
+
+
+def run_once(cmd: str, cwd: Path, output_dir: Path, index: int, forbidden: list[str]) -> RunResult:
+    start = time.time()
+    proc = subprocess.run(cmd, cwd=str(cwd), shell=True, text=True, capture_output=True)
+    duration_ms = int((time.time() - start) * 1000)
+    stdout_path = output_dir / f"run_{index}.stdout.log"
+    stderr_path = output_dir / f"run_{index}.stderr.log"
+    stdout = proc.stdout or ""
+    stderr = proc.stderr or ""
+    stdout_path.write_text(stdout, encoding="utf-8")
+    stderr_path.write_text(stderr, encoding="utf-8")
+    merged = stderr + "\n" + stdout
+    forbidden_hit = ""
+    for pattern in forbidden:
+        if pattern and pattern in merged:
+            forbidden_hit = pattern[:240]
+            break
+    return RunResult(
+        index=index,
+        exit_code=proc.returncode,
+        duration_ms=duration_ms,
+        stdout_file=str(stdout_path),
+        stderr_file=str(stderr_path),
+        forbidden_hit=forbidden_hit,
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.project_root).resolve()
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    forbidden = load_forbidden_patterns(args.signature_file, args.forbidden)
+
+    runs: list[RunResult] = []
+    for i in range(1, args.runs + 1):
+        runs.append(run_once(args.verify_cmd, root, output_dir, i, forbidden))
+
+    all_passed = all(run.exit_code == 0 for run in runs)
+    no_forbidden = all(not run.forbidden_hit for run in runs)
+    verified = all_passed and no_forbidden
+
+    report = {
+        "command": args.verify_cmd,
+        "runs": len(runs),
+        "all_passed": all_passed,
+        "no_forbidden_signature": no_forbidden,
+        "verified": verified,
+        "forbidden_patterns": forbidden,
+        "details": [asdict(run) for run in runs],
+    }
+    report_path = output_dir / "verify_report.json"
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    print(f"report: {report_path}")
+    return 0 if verified else 11
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Introduce a new omnidebug-autopilot skill focused on autonomous root-cause debugging across mainstream languages and frameworks.

Includes browser-specific debugging support with deterministic reproduction rules, evidence collection requirements, and automated verification loops.

Adds references and scripts:\n- browser-repro-playbook.md\n- browser-artifact-checklist.md\n- repro_browser_issue.py\n- capture_browser_artifacts.py\n- verify_browser_fix.py